### PR TITLE
Fix namespace thread unlock

### DIFF
--- a/src/cloud-api-adaptor/pkg/util/netops/netops.go
+++ b/src/cloud-api-adaptor/pkg/util/netops/netops.go
@@ -83,7 +83,7 @@ func OpenCurrentNamespace() (Namespace, error) {
 // CreateNamedNamespace creates a new named network namespace, and returns its path
 func CreateNamedNamespace(name string) (string, error) {
 	runtime.LockOSThread()
-	defer runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	old, err := netns.Get()
 	if err != nil {


### PR DESCRIPTION
## Summary
- correct runtime.UnlockOSThread usage in CreateNamedNamespace

## Testing
- `go vet ./...` *(fails: forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_683ff062f0448321afaa86e6170c7131